### PR TITLE
Added config field, and nested transformation field

### DIFF
--- a/web/models/analysis.py
+++ b/web/models/analysis.py
@@ -22,7 +22,8 @@ class Analysis(db.Model):
     description = db.Column(db.Text)
     data = db.Column(JSONB, default={})
     filters = db.Column(JSONB) # List of filters used to select runs
-    transformations = db.Column(JSONB, default={})
+    transformations = db.Column(JSONB, default=[])
+    config = db.Column(JSONB, default={}) # fMRI analysis parameters
     created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow)
     modified_at = db.Column(db.DateTime, default=datetime.datetime.utcnow)
     saved_count = db.Column(db.Integer, default=0)

--- a/web/resources/analysis.py
+++ b/web/resources/analysis.py
@@ -82,6 +82,13 @@ class TransformationSchema(Schema):
 	inputs = fields.List(fields.Str(), required=True, description='Array of input predictors')
 	parameters = fields.Nested('ParameterSchema', many=True, description='Array of parameters.')
 
+	@validates('inputs')
+	def validate_preds(self, value):
+		try:
+			[Predictor.query.filter_by(id=int(r)).one() for r in value]
+		except:
+			raise ValidationError('Invalid predictor id in transformation input.')
+
 class ParameterSchema(Schema):
 	name = fields.Str(description='Parameter name.', required=True)
 	kind = fields.Str(description='Parameter type (boolean or predictor).',

--- a/web/resources/analysis.py
+++ b/web/resources/analysis.py
@@ -78,14 +78,15 @@ class AnalysisSchema(Schema):
 		strict = True
 
 class TransformationSchema(Schema):
-	name = fields.Str(description='Transformation name.')
-	inputs = fields.List(fields.Str(), description='Array of input predictors')
+	name = fields.Str(description='Transformation name.', required=True)
+	inputs = fields.List(fields.Str(), required=True, description='Array of input predictors')
 	parameters = fields.Nested('ParameterSchema', many=True, description='Array of parameters.')
 
 class ParameterSchema(Schema):
-	name = fields.Str(description='Parameter name.')
-	kind = fields.Str(description='Parameter type (boolean or predictor).')
-	value = fields.Str(description='Parameter value')
+	name = fields.Str(description='Parameter name.', required=True)
+	kind = fields.Str(description='Parameter type (boolean or predictor).',
+					  required=True)
+	value = fields.Str(description='Parameter value', required=True)
 
 @doc(tags=['analysis'])
 @marshal_with(AnalysisSchema)

--- a/web/resources/analysis.py
+++ b/web/resources/analysis.py
@@ -29,10 +29,8 @@ class AnalysisSchema(Schema):
 	parent_id = fields.Str(dump_only=True,description="Parent analysis, if cloned.")
 
 
-	transformations = fields.Nested(
-		'TransformationSchema', many=True,
-		description='Array of transformations'
-	)
+	transformations = fields.List(fields.Dict(),
+								  description='Array of transformation objects')
 	predictors = fields.Nested(
 		'PredictorSchema', many=True, only=['id'],
         description='Predictor id(s) associated with analysis')
@@ -77,30 +75,6 @@ class AnalysisSchema(Schema):
 	class Meta:
 		strict = True
 
-class TransformationSchema(Schema):
-	name = fields.Str(description='Transformation name.', required=True)
-	inputs = fields.List(fields.Int(), required=True, description='Array of input predictors')
-	parameters = fields.Nested('ParameterSchema', many=True, description='Array of parameters.')
-
-	@validates('inputs')
-	def validate_preds(self, value):
-		try:
-			[Predictor.query.filter_by(id=r).one() for r in value]
-		except:
-			raise ValidationError('Invalid predictor id in transformation input.')
-
-class Value(fields.Field):
-	def _serialize(self, value, attr, obj):
-		if value['kind'] == 'boolean':
-		    return bool(value['value'])
-		elif value['kind'] == 'predictor':
-			return int(value['value'])
-		else:
-			raise ValidationError('Invalid value type')
-
-class ParameterSchema(Schema):
-	name = fields.Str(description='Parameter name.', required=True)
-	value = Value(description='Parameter kind and value (in dictionary)', required=True)
 
 @doc(tags=['analysis'])
 @marshal_with(AnalysisSchema)

--- a/web/resources/analysis.py
+++ b/web/resources/analysis.py
@@ -23,12 +23,16 @@ class AnalysisSchema(Schema):
 	private = fields.Bool(description='Analysis private or discoverable?')
 	predictions = fields.Str(description='User apriori predictions.')
 
-	transformations = fields.Dict(description='Transformation json spec.')
+	config = fields.Dict(description='fMRI analysis configuration parameters.')
 	description = fields.Str()
 	data = fields.Dict()
 	parent_id = fields.Str(dump_only=True,description="Parent analysis, if cloned.")
 
 
+	transformations = fields.Nested(
+		'TransformationSchema', many=True,
+		description='Array of transformations'
+	)
 	predictors = fields.Nested(
 		'PredictorSchema', many=True, only=['id'],
         description='Predictor id(s) associated with analysis')
@@ -72,6 +76,16 @@ class AnalysisSchema(Schema):
 
 	class Meta:
 		strict = True
+
+class TransformationSchema(Schema):
+	name = fields.Str(description='Transformation name.')
+	inputs = fields.List(fields.Str(), description='Array of input predictors')
+	parameters = fields.Nested('ParameterSchema', many=True, description='Array of parameters.')
+
+class ParameterSchema(Schema):
+	name = fields.Str(description='Parameter name.')
+	kind = fields.Str(description='Parameter type (boolean or predictor).')
+	value = fields.Str(description='Parameter value')
 
 @doc(tags=['analysis'])
 @marshal_with(AnalysisSchema)

--- a/web/tests/api/test_analyses.py
+++ b/web/tests/api/test_analyses.py
@@ -39,7 +39,7 @@ def test_get(session, auth_client, add_analysis):
 	assert resp.status_code == 404
 	# assert 'requested URL was not found' in decode_json(resp)['message']
 
-def test_post(auth_client, add_dataset):
+def test_post(auth_client, add_dataset, add_predictor):
 	## Add analysis
 	test_analysis = {
 	"dataset_id" : add_dataset,
@@ -47,7 +47,7 @@ def test_post(auth_client, add_dataset):
 	"description" : "pretty damn innovative",
 	"transformations" : [{
 		"name" : "scale",
-		"inputs" : ["predictor_1"],
+		"inputs" : [str(add_predictor)],
 		"parameters" : [
 			{
 				"kind" : "boolean",

--- a/web/tests/api/test_analyses.py
+++ b/web/tests/api/test_analyses.py
@@ -44,7 +44,16 @@ def test_post(auth_client, add_dataset):
 	test_analysis = {
 	"dataset_id" : add_dataset,
 	"name" : "some analysis",
-	"description" : "pretty damn innovative"
+	"description" : "pretty damn innovative",
+	"transformations" : [{
+		"name" : "scale",
+		"inputs" : ["predictor_1"],
+		"parameters" : [
+			{
+				"kind" : "boolean",
+				"name" : "demean",
+				"value" : "true"
+			}]}]
 	}
 
 	resp= auth_client.post('/api/analyses', data = test_analysis)
@@ -78,12 +87,16 @@ def test_post(auth_client, add_dataset):
 
 	bad_post_2 = {
 	"dataset_id" : dataset_id,
-	"description" : "pretty damn innovative"
-	}
+	"description" : "pretty damn innovative",
+	"name" : "analysis_name",
+	"transformations" : [{
+		"inputs" : ["predictor_1"]
+	}]}
 
 	resp= auth_client.post('/api/analyses', data = bad_post_2)
 	assert resp.status_code == 422
-	assert decode_json(resp)['message']['name'][0] == 'Missing data for required field.'
+	assert decode_json(resp)['message']['transformations']['0']['name'][0] \
+			== 'Missing data for required field.' ## Test missing trans. name
 
 def test_clone(session, auth_client, add_dataset, add_analysis, add_users):
 	(id1, id2), _ = add_users

--- a/web/tests/api/test_analyses.py
+++ b/web/tests/api/test_analyses.py
@@ -47,12 +47,11 @@ def test_post(auth_client, add_dataset, add_predictor):
 	"description" : "pretty damn innovative",
 	"transformations" : [{
 		"name" : "scale",
-		"inputs" : [str(add_predictor)],
+		"inputs" : [add_predictor],
 		"parameters" : [
 			{
-				"kind" : "boolean",
 				"name" : "demean",
-				"value" : "true"
+				"value" : {"kind" : "boolean", "value" : True}
 			}]}]
 	}
 
@@ -90,7 +89,7 @@ def test_post(auth_client, add_dataset, add_predictor):
 	"description" : "pretty damn innovative",
 	"name" : "analysis_name",
 	"transformations" : [{
-		"inputs" : ["predictor_1"]
+		"inputs" : [add_predictor]
 	}]}
 
 	resp= auth_client.post('/api/analyses', data = bad_post_2)

--- a/web/tests/api/test_analyses.py
+++ b/web/tests/api/test_analyses.py
@@ -86,16 +86,13 @@ def test_post(auth_client, add_dataset, add_predictor):
 
 	bad_post_2 = {
 	"dataset_id" : dataset_id,
-	"description" : "pretty damn innovative",
-	"name" : "analysis_name",
-	"transformations" : [{
-		"inputs" : [add_predictor]
-	}]}
+	"description" : "pretty damn innovative"
+	}
 
 	resp= auth_client.post('/api/analyses', data = bad_post_2)
 	assert resp.status_code == 422
-	assert decode_json(resp)['message']['transformations']['0']['name'][0] \
-			== 'Missing data for required field.' ## Test missing trans. name
+	assert decode_json(resp)['message']['name'][0] == \
+			'Missing data for required field.'		
 
 def test_clone(session, auth_client, add_dataset, add_analysis, add_users):
 	(id1, id2), _ = add_users


### PR DESCRIPTION
To close #83 and #84 

#84 was straightforward, I added an unstructured JSON field for "config"

For #83, "transformations" field now takes an array of structure JSON  that conforms to the Transformation schema. I've also added a schema for "parameters". This might be overkill but should ensure appropriate inputs. 

My only question is if we should be referring to predictor names in inputs or predictor ids. The latter seems less error prone but is less human readable.