### PR TITLE
Send email confirmation/verification/reset links to users

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,5 @@ You can then insert this token into the header to authorize API requests:
     Authorization: JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZGVudGl0eSI6MSwiaWF0IjoxNDQ0OTE3NjQwLCJuYmYiOjE0NDQ5MTc2NDAsImV4cCI6MTQ0NDkxNzk0MH0.KPmI6WSjRjlpzecPvs3q_T3cJQvAgJvaQAPtk1abC_E
 
 Tokens expire, so you'll probably need to get a new one soon. To facilitate this, I've wrapped a Flask Client that auto authenticates and inserts the token into the header in neuroscout/tests/request_utils.py. You can use this more easily by entering into Shell mode: `python manage.py shell`. A client object will be preloaded (given the username in the file), that can be used to make requests to Flask. Make sure Flask server is also running on localhost.
+
+Note that in order to use any protected routes, you must confirm the email on your account. Confusingly, you can get a valid token without confirming your account, but protected routes will not function until confirmation.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To run tests, after starting services, create a test database:
 
 and execute:
 
-    docker-compose run --rm -w /neuroscout neuroscout python -m pytest
+    docker-compose run -e "APP_SETTINGS=config.config.DockerTestConfig" --rm -w /neuroscout neuroscout python -m pytest
 
 To run frontend tests run:
 

--- a/neuroscout/auth.py
+++ b/neuroscout/auth.py
@@ -20,8 +20,8 @@ def reset_password(email):
     """
     user = User.query.filter_by(email=email).first()
     token = generate_reset_password_token(user) if user else None
-
-    send_reset_mail(email, token)
+    name = user.name if user else None
+    send_reset_mail(email, token, name)
 
 def register_user(**kwargs):
     """ Register new user and password """
@@ -33,7 +33,7 @@ def register_user(**kwargs):
         confirmation_link, token = generate_confirmation_link(user)
 
     if current_app.config['SEND_REGISTER_EMAIL']:
-        send_confirm_mail(user.email, confirmation_link)
+        send_confirm_mail(user.email, user.name, confirmation_link)
 
     return user
 

--- a/neuroscout/auth.py
+++ b/neuroscout/auth.py
@@ -1,18 +1,27 @@
 """ Auth related functions """
-from models.auth import user_datastore
+from models.auth import user_datastore, User
 from flask_security.utils import verify_password
 from flask_security.confirmable import generate_confirmation_token
+from flask_security.recoverable import generate_reset_password_token
 from flask import current_app, url_for
-from mail import send_confirm_mail
+from mail import send_confirm_mail, send_reset_mail
 
 def generate_confirmation_link(user):
-    """ For a given user, generates confirmation link and token
+    """ For a given user, generates confirmation link and token.
     Stand-in for flask_security function that requires enabling other
     non-RESTFul confirmation routes """
     # Use generate_confirmation_token to create token
     token = generate_confirmation_token(user)
     return url_for('confirm', token=token, _external=True), token
 
+def reset_password(email):
+    """Sends the reset password instructions email for the specified email.
+    :param email: The email to send the instructions to
+    """
+    user = User.query.filter_by(email=email).first()
+    token = generate_reset_password_token(user) if user else None
+
+    send_reset_mail(email, token)
 
 def register_user(**kwargs):
     """ Register new user and password """
@@ -24,7 +33,7 @@ def register_user(**kwargs):
         confirmation_link, token = generate_confirmation_link(user)
 
     if current_app.config['SEND_REGISTER_EMAIL']:
-        send_confirm_mail(user.email, confirmation_link=confirmation_link)
+        send_confirm_mail(user.email, confirmation_link)
 
     return user
 
@@ -48,40 +57,26 @@ def add_auth_to_swagger(spec):
         operations=dict(
             post=dict(
                 parameters=[
-              {
-                "in": "body",
-                "name": "body",
-                "required": True,
-                "schema": {
-                  "properties": {
-                    "email": {
-                      "type": "string"
-                    },
-                    "password": {
-                      "type": "string"
-                    }},
-                  "type": "object",
-                  "example" : { "email" : "user@example.com", "password" : "string" },
-                }
-              }
-            ],
-               tags = [
-                  "auth"
-                ],
-               summary = "Get JWT authorizaton token.",
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "required": True,
+                        "schema": {
+                            "properties": {"email": {"type": "string"},
+                                           "password": {"type": "string"}},
+                            "type": "object",
+                            "example" : {
+                                "email" : "user@example.com",
+                                "password" : "string" }}
+                        }
+                    ],
+                tags = ["auth"],
+                summary = "Get JWT authorizaton token.",
                 responses={
-     "default": {
-                "description": "",
-                "schema": {
-                  "properties": {
-                    "authorizaton_token": {
-                      "type": "string"
-                    },
-                  "type": "object"
-                }
-              }
-                }
-     }
-            )
-        )
-    )
+                    "default": {
+                        "description": "",
+                        "schema": {
+                            "properties": {
+                                "authorizaton_token": {"type": "string"},
+                                "type": "object"
+                                }}}})))

--- a/neuroscout/auth.py
+++ b/neuroscout/auth.py
@@ -1,3 +1,4 @@
+""" Auth related functions """
 from models.auth import user_datastore
 from flask_security.utils import verify_password
 from flask_security.confirmable import generate_confirmation_token

--- a/neuroscout/config/config.py
+++ b/neuroscout/config/config.py
@@ -32,18 +32,18 @@ class DevelopmentConfig(Config):
     MIGRATIONS_DIR = '/migrations/migrations'
     DATASET_DIR = '/file-data'
 
-class DockerTestConfig(Config):
-    SQLALCHEMY_DATABASE_URI = 'postgres://postgres@postgres:5432/scout_test'
+class TestingConfig(Config):
     TESTING = True
 
-class TestingConfig(Config):
+class DockerTestConfig(TestingConfig):
+    SQLALCHEMY_DATABASE_URI = 'postgres://postgres@postgres:5432/scout_test'
+
+class HomeTestingConfig(TestingConfig):
     SQLALCHEMY_DATABASE_URI = 'postgresql://zorro:dbpass@localhost:5432/scout_test'
-    TESTING = True
     DATASET_DIR = '/tmp/file-data'
 
-class TravisConfig(Config):
+class TravisConfig(TestingConfig):
     SQLALCHEMY_DATABASE_URI = "postgresql://postgres@localhost/travis_ci_test"
-    TESTING = True
     DATASET_DIR = '/tmp/file-data'
 
 class HomeConfig(Config):

--- a/neuroscout/config/config.py
+++ b/neuroscout/config/config.py
@@ -6,20 +6,24 @@ class Config(object):
     CSRF_ENABLED = True
     SECRET_KEY = 'secret'
     SECURITY_PASSWORD_HASH = 'pbkdf2_sha512'
-    SECURITY_TRACKABLE = True
     SECURITY_PASSWORD_SALT = 'shh_this_is_a_secret'
-    SECURITY_REGISTERABLE = True
-    SECURITY_RECOVERABLE = True
-    SECURITY_TRACKABLE = True
     WTF_CSRF_ENABLED = False
-    SQLALCHEMY_TRACK_MODIFICATIONS = False
     JWT_EXPIRATION_DELTA = datetime.timedelta(days=7)
     JWT_AUTH_URL_RULE = '/api/auth'
+    JWT_AUTH_USERNAME_KEY = 'email'
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    HASH_SALT = 'lksjdfkljsflkjdf'
     MIGRATIONS_DIR = 'migrations'
     APISPEC_SWAGGER_UI_URL = None
-    HASH_SALT = 'lksjdfkljsflkjdf'
-    JWT_AUTH_USERNAME_KEY = 'email'
 
+    MAIL_SERVER = 'smtp.mailgun.org'
+    MAIL_USERNAME = 'postmaster@sandbox313ed2a0563245c1827937801e1676a8.mailgun.org'
+    MAIL_PASSWORD = 'YhhgT$y30LzD'
+    MAIL_DEFAULT_SENDER = 'no-reply@neuroscout.org'
+    SECURITY_EMAIL_SENDER = 'no-reply@neuroscout.org'
+
+    CONFIRM_USERS = True
+    SEND_REGISTER_EMAIL = True
 
 class DevelopmentConfig(Config):
     DEBUG = True

--- a/neuroscout/core.py
+++ b/neuroscout/core.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """ Core Neuroscout App """
 import os
-from flask import Flask, send_file, render_template
+from flask import Flask, send_file, render_template, url_for
 from database import db
 
 app = Flask(__name__, static_folder='/static')
@@ -76,12 +76,15 @@ def index():
 def confirm(token):
     ''' Serve confirmaton page '''
     expired, invalid, user = confirm_email_token_status(token)
+    name = user.name if user else None
     if not expired and not invalid:
         confirmed = confirm_user(user)
         db.session.commit()
+    app.logger.info(confirmed)
     return render_template('confirm.html',
-                           confirmed=confirmed, expired=expired, invalid=invalid,
-                           email=user.email)
+                           confirmed=confirmed, expired=expired,
+                           invalid=invalid, name=name,
+                           action_url=url_for('index', _external=True))
 
 if __name__ == '__main__':
     db.init_app(app)

--- a/neuroscout/core.py
+++ b/neuroscout/core.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
 import os
-from flask import Flask, send_file
+from flask import Flask, send_file, render_template
+from flask_mail import Mail
 from database import db
 
 app = Flask(__name__, static_folder='/static')
 app.config.from_object(os.environ['APP_SETTINGS'])
+mail = Mail(app)
 db.init_app(app)
 
 from flask_jwt import JWT
 from flask_security import Security
+from flask_security.confirmable import confirm_email_token_status, confirm_user
 from auth import authenticate, load_user, add_auth_to_swagger
 from models import *
 
@@ -48,7 +51,7 @@ route_factory(app, docs,
         ('AnalysisResourcesResource', 'analyses/<analysis_id>/resources'),
         ('AnalysisBundleResource', 'analyses/<analysis_id>/bundle'),
         ('DesignEventsResource', 'analyses/<analysis_id>/design/events'),
-        # ('DesignEventsResource', 'analyses/<analysis_id>/design/events/tsv'),        
+        # ('DesignEventsResource', 'analyses/<analysis_id>/design/events/tsv'),
         ('ResultResource', 'results/<int:result_id>'),
         ('RunListResource', 'runs'),
         ('RunResource', 'runs/<int:run_id>'),
@@ -64,6 +67,17 @@ route_factory(app, docs,
 def index():
     ''' Serve index '''
     return send_file("frontend/build/index.html")
+
+@app.route('/confirm/<token>')
+def confirm(token):
+    ''' Serve confirmaton page '''
+    expired, invalid, user = confirm_email_token_status(token)
+    if not expired and not invalid:
+        confirmed = confirm_user(user)
+        db.session.commit()
+    return render_template('confirm.html',
+                           confirmed=confirmed, expired=expired, invalid=invalid,
+                           email=user.email)
 
 if __name__ == '__main__':
     db.init_app(app)

--- a/neuroscout/core.py
+++ b/neuroscout/core.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 import os
 from flask import Flask, send_file, render_template
-from flask_mail import Mail
 from database import db
 
 app = Flask(__name__, static_folder='/static')
 app.config.from_object(os.environ['APP_SETTINGS'])
-mail = Mail(app)
 db.init_app(app)
+
+from flask_mail import Mail
+mail = Mail(app)
 
 from flask_jwt import JWT
 from flask_security import Security

--- a/neuroscout/core.py
+++ b/neuroscout/core.py
@@ -61,6 +61,8 @@ route_factory(app, docs,
         ('PredictorResource', 'predictors/<int:predictor_id>'),
         ('PredictorEventListResource', 'predictor-events'),
         ('UserRootResource', 'user'),
+        ('UserTriggerResetResource', 'user/reset_password'),
+        ('UserResetSubmitResource', 'user/submit_token'),
         ('TaskResource', 'tasks/<int:task_id>'),
         ('TaskListResource', 'tasks')
     ])

--- a/neuroscout/core.py
+++ b/neuroscout/core.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+""" Core Neuroscout App """
 import os
 from flask import Flask, send_file, render_template
 from database import db

--- a/neuroscout/database.py
+++ b/neuroscout/database.py
@@ -1,3 +1,4 @@
+""" Set up app database """
 from flask_sqlalchemy import SQLAlchemy
 
 db = SQLAlchemy()

--- a/neuroscout/db_utils.py
+++ b/neuroscout/db_utils.py
@@ -1,3 +1,6 @@
+"""
+    Misc utils related to database functions.
+"""
 from flask import abort, current_app
 from sqlalchemy.exc import SQLAlchemyError
 

--- a/neuroscout/mail.py
+++ b/neuroscout/mail.py
@@ -1,32 +1,36 @@
 """
     Mail sending functionality using flask_mail.
 """
+from flask import render_template
 from flask_mail import Message
 from core import mail
 
-def send_confirm_mail(recipient, confirmation_link):
-    """Send an email via the Flask-Mail extension.
+def send_confirm_mail(recipient, name, confirmation_link):
+    """Send account confirmation email
     :param recipient: Email recipient
     :param confirmation_link: The reset link to send
     """
 
     msg = Message("Welcome to Neuroscout!",
                   recipients=[recipient])
-    msg.html = "<a href={}>Confirm account</a>".format(confirmation_link)
+    msg.html = render_template('welcome_email.html',
+                               action_url=confirmation_link,
+                               name=name,
+                               support_email='delavega@utexas.edu')
     mail.send(msg)
 
-def send_reset_mail(recipient, token):
-    """Send an email via the Flask-Mail extension.
+def send_reset_mail(recipient, token, name):
+    """Send a password reset email
     :param recipient: Email recipient
     :param token: The password reset token
     """
 
-    msg = Message("Password reset token",
+    msg = Message("Neuroscout password reset",
                   recipients=[recipient])
 
-    if token is None:
-        msg.html = "This account doesn't exist!"
-    else:
-        msg.html = "Reset token: {}".format(token)
+    msg.html = render_template('password_reset.html',
+                               token=token,
+                               name=name,
+                               support_email='delavega@utexas.edu')
 
     mail.send(msg)

--- a/neuroscout/mail.py
+++ b/neuroscout/mail.py
@@ -1,3 +1,6 @@
+"""
+    Mail sending functionality using flask_mail.
+"""
 from flask_mail import Message
 from core import mail
 def send_confirm_mail(recipient, confirmation_link):

--- a/neuroscout/mail.py
+++ b/neuroscout/mail.py
@@ -3,18 +3,30 @@
 """
 from flask_mail import Message
 from core import mail
+
 def send_confirm_mail(recipient, confirmation_link):
     """Send an email via the Flask-Mail extension.
-    :param subject: Email subject
     :param recipient: Email recipient
-    :param template: The name of the email template
-    :param context: The context to render the template with
+    :param confirmation_link: The reset link to send
     """
 
     msg = Message("Welcome to Neuroscout!",
                   recipients=[recipient])
-
-    # To-do implement email templates
     msg.html = "<a href={}>Confirm account</a>".format(confirmation_link)
+    mail.send(msg)
+
+def send_reset_mail(recipient, token):
+    """Send an email via the Flask-Mail extension.
+    :param recipient: Email recipient
+    :param token: The password reset token
+    """
+
+    msg = Message("Password reset token",
+                  recipients=[recipient])
+
+    if token is None:
+        msg.html = "This account doesn't exist!"
+    else:
+        msg.html = "Reset token: {}".format(token)
 
     mail.send(msg)

--- a/neuroscout/mail.py
+++ b/neuroscout/mail.py
@@ -1,0 +1,17 @@
+from flask_mail import Message
+from core import mail
+def send_confirm_mail(recipient, confirmation_link):
+    """Send an email via the Flask-Mail extension.
+    :param subject: Email subject
+    :param recipient: Email recipient
+    :param template: The name of the email template
+    :param context: The context to render the template with
+    """
+
+    msg = Message("Welcome to Neuroscout!",
+                  recipients=[recipient])
+
+    # To-do implement email templates
+    msg.html = "<a href={}>Confirm account</a>".format(confirmation_link)
+
+    mail.send(msg)

--- a/neuroscout/manage.py
+++ b/neuroscout/manage.py
@@ -1,3 +1,7 @@
+"""
+    Command line management tools.
+"""
+
 from flask_script import Manager, Shell
 from flask_migrate import Migrate, MigrateCommand
 from core import app, db
@@ -30,26 +34,30 @@ manager.add_command("shell", Shell(make_context=_make_context))
 
 @manager.command
 def add_user(email, password):
-    from models import user_datastore
-    from flask_security.utils import encrypt_password
+	""" Add a user to the database.
+	email - A valid email address (primary login key)
+	password - Any string
+	"""
+	from models import user_datastore
+	from flask_security.utils import encrypt_password
 
-    user_datastore.create_user(email=email, password=encrypt_password(password))
-    db.session.commit()
+	user_datastore.create_user(email=email, password=encrypt_password(password))
+	db.session.commit()
 
 @manager.command
 def add_task(local_path, task, replace=False, automagic=False,
-		skip_predictors=False, filters='{}'):
-		""" Add BIDS dataset to database.
-		local_path - Path to local_path directory
-		task - Task name
-		replace - If dataset is already in db, re-ingest?
-		automagic - Force enable datalad automagic
-		skip_predictors - Skip original Predictors
-		filters - string JSON object with optional run filters
-		"""
-		populate.add_task(db.session, task, local_path=local_path,
-				 replace=replace, verbose=True, skip_predictors=skip_predictors,
-				 automagic=automagic, **json.loads(filters))
+	skip_predictors=False, filters='{}'):
+	""" Add BIDS dataset to database.
+	local_path - Path to local_path directory
+	task - Task name
+	replace - If dataset is already in db, re-ingest?
+	automagic - Force enable datalad automagic
+	skip_predictors - Skip original Predictors
+	filters - string JSON object with optional run filters
+	"""
+	populate.add_task(db.session, task, local_path=local_path,
+			 replace=replace, verbose=True, skip_predictors=skip_predictors,
+			 automagic=automagic, **json.loads(filters))
 
 @manager.command
 def extract_features(local_path, task, graph_spec, filters='{}'):

--- a/neuroscout/models/auth.py
+++ b/neuroscout/models/auth.py
@@ -19,9 +19,7 @@ class User(db.Model, UserMixin):
     roles = db.relationship('Role', secondary=roles_users,
                             backref=db.backref('users', lazy='dynamic'))
     last_login_at = db.Column(db.DateTime())
-    current_login_at = db.Column(db.DateTime())
     last_login_ip = db.Column(db.String(255))
-    current_login_ip = db.Column(db.String(255))
     login_count = db.Column(db.Integer)
 
     analyses = db.relationship('Analysis', backref='user',

--- a/neuroscout/models/auth.py
+++ b/neuroscout/models/auth.py
@@ -18,9 +18,8 @@ class User(db.Model, UserMixin):
     confirmed_at = db.Column(db.DateTime())
     roles = db.relationship('Role', secondary=roles_users,
                             backref=db.backref('users', lazy='dynamic'))
-    last_login_at = db.Column(db.DateTime())
-    last_login_ip = db.Column(db.String(255))
-    login_count = db.Column(db.Integer)
+    last_activity_at = db.Column(db.DateTime())
+    last_activity_ip = db.Column(db.String(255))
 
     analyses = db.relationship('Analysis', backref='user',
                             lazy='dynamic')

--- a/neuroscout/populate.py
+++ b/neuroscout/populate.py
@@ -1,4 +1,6 @@
-""" Functions to populate database from datasets and extracted features """
+"""
+    Functions to populate database from datasets and extracted features.
+"""
 import os
 import re
 import json

--- a/neuroscout/resources/__init__.py
+++ b/neuroscout/resources/__init__.py
@@ -11,7 +11,8 @@ from .predictor import (PredictorEventSchema, PredictorSchema,
 from .result import ResultSchema, ResultResource
 from .run import RunSchema, RunResource, RunListResource
 from .stimulus import StimulusSchema, StimulusResource
-from .user import UserSchema, UserRootResource
+from .user import (UserSchema, UserRootResource, UserTriggerResetResource,
+                   UserResetSubmitResource)
 from .task import TaskSchema, TaskResource, TaskListResource
 
 __all__ = [
@@ -41,6 +42,8 @@ __all__ = [
     'UserSchema',
     'UserRootResource',
     'UserSchema',
+    'UserTriggerResetResource',
+    'UserResetSubmitResource',
     'TaskSchema',
     'TaskResource',
     'TaskListResource'

--- a/neuroscout/resources/user.py
+++ b/neuroscout/resources/user.py
@@ -6,7 +6,6 @@ from marshmallow import Schema, fields, validates, ValidationError, post_load
 from models.auth import User
 from database import db
 from auth import register_user
-from models import user_datastore
 from . import utils
 import db_utils
 from .utils import abort

--- a/neuroscout/resources/user.py
+++ b/neuroscout/resources/user.py
@@ -1,11 +1,13 @@
 from flask_jwt import current_identity
 from flask_security.utils import encrypt_password
+from flask_security.recoverable import reset_password_token_status
+
 
 from flask_apispec import MethodResource, marshal_with, use_kwargs, doc
 from marshmallow import Schema, fields, validates, ValidationError, post_load
 from models.auth import User
 from database import db
-from auth import register_user
+from auth import register_user, reset_password
 from . import utils
 import db_utils
 from .utils import abort
@@ -43,7 +45,8 @@ class UserCreationSchema(UserSchema):
     	if User.query.filter_by(email=value).first():
     		raise ValidationError('Email already in use.')
 
-
+class UserResetSchema(UserCreationSchema):
+    token = fields.Str(required=True, description="Password reset token.")
 
 @doc(tags=['auth'])
 @marshal_with(UserSchema)
@@ -66,3 +69,24 @@ class UserRootResource(MethodResource):
                              & (User.id!=current_identity.id)).all():
             abort(422, 'Email already in use.')
         return db_utils.put_record(db.session, kwargs, current_identity)
+
+@doc(tags=['auth'], summary='Request a password reset token.')
+@use_kwargs(UserSchema(only=['email']))
+class UserTriggerResetResource(MethodResource):
+    def post(self, **kwargs):
+        reset_password(kwargs['email'])
+        return {'message' : 'Password reset token sent'}, 200
+
+@doc(tags=['auth'], summary='Reset user password using a token.')
+@use_kwargs(UserCreationSchema(only=['token', 'password']))
+class UserResetSubmitResource(MethodResource):
+    def post(self, **kwargs):
+        expired, invalid, user = reset_password_token_status(kwargs['token'])
+        if expired:
+            abort(422, 'Password reset token expired.')
+        elif invalid:
+            abort(422, 'Invalid password reset token.')
+        else:
+            user.password = kwargs['password']
+            db.session.commit()
+            return {'message' : 'Password reset succesfully.'}, 200

--- a/neuroscout/resources/utils.py
+++ b/neuroscout/resources/utils.py
@@ -58,15 +58,18 @@ def auth_required(function):
     "description": "Format:  JWT {authorization_token}"}})
     @jwt_required()
     def wrapper(*args, **kwargs):
+        # Record activity time and IP
         current_identity.last_activity_at = datetime.datetime.now()
         current_identity.last_activity_ip = request.remote_addr
         db.session.commit()
+
         if current_identity.active is False:
             return abort(
                 401, {"message" : "Your account has been disabled."})
         elif current_identity.confirmed_at is None:
             return abort(
                 401, {"message" : "Your account has not been confirmed."})
+
         return function(*args, **kwargs)
     return wrapper
 

--- a/neuroscout/templates/confirm.html
+++ b/neuroscout/templates/confirm.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<title>Confimation</title>
+{% if status=='CONFIRMED' %}
+  <h1>User confirmed</h1>
+{% elif status=='FAILED' %}
+  <h1>User could not be confirmed</h1>
+
+{% endif %}

--- a/neuroscout/templates/confirm.html
+++ b/neuroscout/templates/confirm.html
@@ -1,8 +1,97 @@
-<!doctype html>
-<title>Confimation</title>
-{% if status=='CONFIRMED' %}
-  <h1>User confirmed</h1>
-{% elif status=='FAILED' %}
-  <h1>User could not be confirmed</h1>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Account confirmation</title>
 
-{% endif %}
+
+  </head>
+  <body style="-webkit-text-size-adjust: none; box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; height: 100%; line-height: 1.4; margin: 0; width: 100% !important;" bgcolor="#F2F4F6"><style type="text/css">
+body {
+width: 100% !important; height: 100%; margin: 0; line-height: 1.4; background-color: #F2F4F6; color: #74787E; -webkit-text-size-adjust: none;
+}
+@media only screen and (max-width: 600px) {
+  .email-body_inner {
+    width: 100% !important;
+  }
+  .email-footer {
+    width: 100% !important;
+  }
+}
+@media only screen and (max-width: 500px) {
+  .button {
+    width: 100% !important;
+  }
+}
+</style>
+    <span class="preheader" style="box-sizing: border-box; display: none !important; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 1px; line-height: 1px; max-height: 0; max-width: 0; mso-hide: all; opacity: 0; overflow: hidden; visibility: hidden;">Password reset request.</span>
+    <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0; padding: 0; width: 100%;" bgcolor="#F2F4F6">
+      <tr>
+        <td align="center" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; word-break: break-word;">
+          <table class="email-content" width="100%" cellpadding="0" cellspacing="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0; padding: 0; width: 100%;">
+            <tr>
+              <td class="email-masthead" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; padding: 25px 0; word-break: break-word;" align="center">
+                <a href="https://neuroscout.org" class="email-masthead_name" style="box-sizing: border-box; color: #bbbfc3; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 16px; font-weight: bold; text-decoration: none; text-shadow: 0 1px 0 white;">
+        Neuroscout ⚜️
+      </a>
+              </td>
+            </tr>
+            <tr>
+              <td class="email-body" width="100%" cellpadding="0" cellspacing="0" style="-premailer-cellpadding: 0; -premailer-cellspacing: 0; border-bottom-color: #EDEFF2; border-bottom-style: solid; border-bottom-width: 1px; border-top-color: #EDEFF2; border-top-style: solid; border-top-width: 1px; box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0; padding: 0; width: 100%; word-break: break-word;" bgcolor="#FFFFFF">
+                <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0 auto; padding: 0; width: 570px;" bgcolor="#FFFFFF">
+
+                  <tr>
+
+                    <td class="content-cell" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; padding: 35px; word-break: break-word;">
+                      {% if confirmed == true %}
+
+
+                      <h1 style="box-sizing: border-box; color: #2F3133; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 19px; font-weight: bold; margin-top: 0;" align="left">Hi {{ name }},</h1>
+                      <p style="box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 16px; line-height: 1.5em; margin-top: 0;" align="left">
+                       Your Neurosynth account has been activated. <br/>
+                       You can now start using Neurosynth! <a href = {{ action_url }}>Click here to log in to your account.</a>
+
+                      {% elif expired == true %}
+
+                        <h1 style="box-sizing: border-box; color: #2F3133; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 19px; font-weight: bold; margin-top: 0;" align="left">Hello,</h1>
+                        <p style="box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 16px; line-height: 1.5em; margin-top: 0;" align="left">
+                         The confirmation token you've tried to use is expired. Please try again
+
+                      {% else %}
+                      <h1 style="box-sizing: border-box; color: #2F3133; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 19px; font-weight: bold; margin-top: 0;" align="left">Hello,</h1>
+                      <p style="box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 16px; line-height: 1.5em; margin-top: 0;" align="left">
+                       The confirmation token you've tried to use is invalid. Please try again
+
+                      {% endif %}
+
+
+                      <p style="box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 16px; line-height: 1.5em; margin-top: 0;" align="left">Thanks,
+                        <br />The Neuroscout Team</p>
+
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; word-break: break-word;">
+                <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0 auto; padding: 0; text-align: center; width: 570px;">
+                  <tr>
+                    <td class="content-cell" align="center" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; padding: 35px; word-break: break-word;">
+                      <p class="sub align-center" style="box-sizing: border-box; color: #AEAEAE; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 12px; line-height: 1.5em; margin-top: 0;" align="center">© 2017 Neuroscout. All rights reserved.</p>
+                      <p class="sub align-center" style="box-sizing: border-box; color: #AEAEAE; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 12px; line-height: 1.5em; margin-top: 0;" align="center">
+                        Neuroscout
+                        <br />University of Texas at Austin
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/neuroscout/templates/password_reset.html
+++ b/neuroscout/templates/password_reset.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Set up a new password for Neuroscout</title>
+
+
+  </head>
+  <body style="-webkit-text-size-adjust: none; box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; height: 100%; line-height: 1.4; margin: 0; width: 100% !important;" bgcolor="#F2F4F6"><style type="text/css">
+body {
+width: 100% !important; height: 100%; margin: 0; line-height: 1.4; background-color: #F2F4F6; color: #74787E; -webkit-text-size-adjust: none;
+}
+@media only screen and (max-width: 600px) {
+  .email-body_inner {
+    width: 100% !important;
+  }
+  .email-footer {
+    width: 100% !important;
+  }
+}
+@media only screen and (max-width: 500px) {
+  .button {
+    width: 100% !important;
+  }
+}
+</style>
+    <span class="preheader" style="box-sizing: border-box; display: none !important; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 1px; line-height: 1px; max-height: 0; max-width: 0; mso-hide: all; opacity: 0; overflow: hidden; visibility: hidden;">Password reset request.</span>
+    <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0; padding: 0; width: 100%;" bgcolor="#F2F4F6">
+      <tr>
+        <td align="center" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; word-break: break-word;">
+          <table class="email-content" width="100%" cellpadding="0" cellspacing="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0; padding: 0; width: 100%;">
+            <tr>
+              <td class="email-masthead" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; padding: 25px 0; word-break: break-word;" align="center">
+                <a href="https://neuroscout.org" class="email-masthead_name" style="box-sizing: border-box; color: #bbbfc3; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 16px; font-weight: bold; text-decoration: none; text-shadow: 0 1px 0 white;">
+        Neuroscout ⚜️
+      </a>
+              </td>
+            </tr>
+            <tr>
+              <td class="email-body" width="100%" cellpadding="0" cellspacing="0" style="-premailer-cellpadding: 0; -premailer-cellspacing: 0; border-bottom-color: #EDEFF2; border-bottom-style: solid; border-bottom-width: 1px; border-top-color: #EDEFF2; border-top-style: solid; border-top-width: 1px; box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0; padding: 0; width: 100%; word-break: break-word;" bgcolor="#FFFFFF">
+                <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0 auto; padding: 0; width: 570px;" bgcolor="#FFFFFF">
+
+                  <tr>
+
+                    <td class="content-cell" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; padding: 35px; word-break: break-word;">
+                      {% if token is not none %}
+
+                      <h1 style="box-sizing: border-box; color: #2F3133; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 19px; font-weight: bold; margin-top: 0;" align="left">Hi {{name}},</h1>
+                      <p style="box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 16px; line-height: 1.5em; margin-top: 0;" align="left">You recently requested to reset your password for your Neuroscout account. Use the token below to reset your password. <strong style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;">This token is valid for 5 days.</strong></p>
+
+                      <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 30px auto; padding: 0; text-align: center; width: 100%;">
+                        <tr>
+                          <td align="center" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; word-break: break-word;">
+
+                            <table width="100%" border="0" cellspacing="0" cellpadding="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;">
+                              <tr>
+                                <td align="center" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; word-break: break-word;">
+                                  <table border="0" cellspacing="0" cellpadding="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;">
+                                    <tr>
+                                      <td style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; word-break: break-word;">
+                                        <strong>{{token}}</strong>
+                                      </td>
+                                    </tr>
+                                  </table>
+                                </td>
+                              </tr>
+                            </table>
+                          </td>
+                        </tr>
+                      </table>
+                      {% else %}
+                      <td class="content-cell" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; padding: 35px; word-break: break-word;">
+                        <h1 style="box-sizing: border-box; color: #2F3133; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 19px; font-weight: bold; margin-top: 0;" align="left">Hello,</h1>
+                        <p style="box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 16px; line-height: 1.5em; margin-top: 0;" align="left">
+                         We received a request to reset the password of an account associated with this email address but no matching account could be found.
+                         If you made this request, perhaps your account is associated with a different email address, or you still need to create an account?
+                        {%endif %}
+
+                      <p style="box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 16px; line-height: 1.5em; margin-top: 0;" align="left">If you did not request a password reset, please ignore this email or <a href="{{support_url}}" style="box-sizing: border-box; color: #3869D4; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;">contact support</a> if you have questions.</p>
+                      <p style="box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 16px; line-height: 1.5em; margin-top: 0;" align="left">Thanks,
+                        <br />The Neuroscout Team</p>
+
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; word-break: break-word;">
+                <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0 auto; padding: 0; text-align: center; width: 570px;">
+                  <tr>
+                    <td class="content-cell" align="center" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; padding: 35px; word-break: break-word;">
+                      <p class="sub align-center" style="box-sizing: border-box; color: #AEAEAE; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 12px; line-height: 1.5em; margin-top: 0;" align="center">© 2017 Neuroscout. All rights reserved.</p>
+                      <p class="sub align-center" style="box-sizing: border-box; color: #AEAEAE; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 12px; line-height: 1.5em; margin-top: 0;" align="center">
+                        Neuroscout
+                        <br />University of Texas at Austin
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/neuroscout/templates/welcome_email.html
+++ b/neuroscout/templates/welcome_email.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Welcome to Neuroscout, {{name}}!</title>
+
+
+  </head>
+
+  <body style="-webkit-text-size-adjust: none; box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; height: 100%; line-height: 1.4; margin: 0; width: 100% !important;" bgcolor="#F2F4F6"><style type="text/css">
+body {
+width: 100% !important; height: 100%; margin: 0; line-height: 1.4; background-color: #F2F4F6; color: #74787E; -webkit-text-size-adjust: none;
+}
+@media only screen and (max-width: 600px) {
+  .email-body_inner {
+    width: 100% !important;
+  }
+  .email-footer {
+    width: 100% !important;
+  }
+}
+@media only screen and (max-width: 500px) {
+  .button {
+    width: 100% !important;
+  }
+}
+</style>
+
+    <span class="preheader" style="box-sizing: border-box; display: none !important; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 1px; line-height: 1px; max-height: 0; max-width: 0; mso-hide: all; opacity: 0; overflow: hidden; visibility: hidden;">
+      Thanks for signing up for Neuroscout.</span>
+    <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0; padding: 0; width: 100%;" bgcolor="#F2F4F6">
+      <tr>
+        <td align="center" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; word-break: break-word;">
+          <table class="email-content" width="100%" cellpadding="0" cellspacing="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0; padding: 0; width: 100%;">
+            <tr>
+              <td class="email-masthead" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; padding: 25px 0; word-break: break-word;" align="center">
+                <a href="https://neuroscout.org" class="email-masthead_name" style="box-sizing: border-box; color: #bbbfc3; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 16px; font-weight: bold; text-decoration: none; text-shadow: 0 1px 0 white;">
+        Neuroscout ⚜️
+      </a>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="email-body" width="100%" cellpadding="0" cellspacing="0" style="-premailer-cellpadding: 0; -premailer-cellspacing: 0; border-bottom-color: #EDEFF2; border-bottom-style: solid; border-bottom-width: 1px; border-top-color: #EDEFF2; border-top-style: solid; border-top-width: 1px; box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0; padding: 0; width: 100%; word-break: break-word;" bgcolor="#FFFFFF">
+                <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0 auto; padding: 0; width: 570px;" bgcolor="#FFFFFF">
+
+                  <tr>
+                    <td class="content-cell" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; padding: 35px; word-break: break-word;">
+                      <h1 style="box-sizing: border-box; color: #2F3133; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 19px; font-weight: bold; margin-top: 0;" align="left">Welcome, {{name}}!</h1>
+                      <p style="box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 16px; line-height: 1.5em; margin-top: 0;" align="left">Thanks for signing up for Neuroscout.</p>
+                      <p style="box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 16px; line-height: 1.5em; margin-top: 0;" align="left">To get started, click below to confirm your email address:</p>
+
+                      <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 30px auto; padding: 0; text-align: center; width: 100%;">
+                        <tr>
+                          <td align="center" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; word-break: break-word;">
+
+                            <table width="100%" border="0" cellspacing="0" cellpadding="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;">
+                              <tr>
+                                <td align="center" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; word-break: break-word;">
+                                  <table border="0" cellspacing="0" cellpadding="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;">
+                                    <tr>
+                                      <td style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; word-break: break-word;">
+                                        <a href="{{action_url}}" class="button button--" target="_blank" style="-webkit-text-size-adjust: none; background: #3869D4; border-color: #3869d4; border-radius: 3px; border-style: solid; border-width: 10px 18px; box-shadow: 0 2px 3px rgba(0, 0, 0, 0.16); box-sizing: border-box; color: #FFF; display: inline-block; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; text-decoration: none;">Confirm Email</a>
+                                      </td>
+                                    </tr>
+                                  </table>
+                                </td>
+                              </tr>
+                            </table>
+                          </td>
+                        </tr>
+                      </table>
+                      <p style="box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 16px; line-height: 1.5em; margin-top: 0;" align="left">For reference, this email address is your primary user name.</p>
+                      <p style="box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 16px; line-height: 1.5em; margin-top: 0;" align="left">If you have any questions, feel free to <a href="mailto:{{support_email}}" style="box-sizing: border-box; color: #3869D4; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;">email us</a>.
+                      <p style="box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 16px; line-height: 1.5em; margin-top: 0;" align="left">Thanks,
+                        <br />The Neuroscout Team</p>
+                      <table class="body-sub" style="border-top-color: #EDEFF2; border-top-style: solid; border-top-width: 1px; box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin-top: 25px; padding-top: 25px;">
+                        <tr>
+                          <td style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; word-break: break-word;">
+                            <p class="sub" style="box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 12px; line-height: 1.5em; margin-top: 0;" align="left">If you’re having trouble with the button above, copy and paste the URL below into your web browser.</p>
+                            <p class="sub" style="box-sizing: border-box; color: #74787E; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 12px; line-height: 1.5em; margin-top: 0;" align="left">{{action_url}}</p>
+                          </td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; word-break: break-word;">
+                <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0 auto; padding: 0; text-align: center; width: 570px;">
+                  <tr>
+                    <td class="content-cell" align="center" style="box-sizing: border-box; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; padding: 35px; word-break: break-word;">
+                      <p class="sub align-center" style="box-sizing: border-box; color: #AEAEAE; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 12px; line-height: 1.5em; margin-top: 0;" align="center">
+                        Neuroscout
+                        <br />University of Texas at Austin
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/neuroscout/tests/api/test_analyses.py
+++ b/neuroscout/tests/api/test_analyses.py
@@ -253,7 +253,7 @@ def test_compile(auth_client, add_analysis, add_analysis_fail):
 	# Test getting event files
 	resp = auth_client.get('/api/analyses/{}/design/events'.format(analysis.hash_id))
 	assert resp.status_code == 200
-	assert len(decode_json(resp)) == 32
+	assert len(decode_json(resp)) == 48
 
 def test_auth_id(auth_client, add_analysis_user2):
 	# Try deleting analysis you are not owner of

--- a/neuroscout/tests/api/test_user.py
+++ b/neuroscout/tests/api/test_user.py
@@ -1,4 +1,5 @@
 import json
+import datetime
 
 def decode_json(resp):
 	return json.loads(resp.data.decode())
@@ -22,10 +23,14 @@ def test_auth(auth_client):
 	assert decode_json(resp)['description'] == 'Request does not contain an access token'
 
 def test_get(auth_client):
+	time = datetime.datetime.now()
 	resp = auth_client.get('/api/user')
 	assert resp.status_code == 200
-
 	assert 'email' in decode_json(resp)
+
+	user = User.query.filter_by(email=decode_json(resp)['email']).one()
+	assert user.last_activity_at > time
+	assert user.last_activity_ip is not None
 
 def test_put(auth_client):
 	# Testing changing name

--- a/neuroscout/utils.py
+++ b/neuroscout/utils.py
@@ -1,3 +1,6 @@
+"""
+    Misc. utilities useful across package.
+"""
 import requests
 import urllib.parse
 

--- a/neuroscout/utils.py
+++ b/neuroscout/utils.py
@@ -2,6 +2,7 @@ import requests
 import urllib.parse
 
 def hash_file(f, blocksize=65536):
+    """ Hash a file, given a file name string """
     import hashlib
     hasher = hashlib.sha1()
     with open(f, 'rb') as afile:
@@ -12,6 +13,7 @@ def hash_file(f, blocksize=65536):
     return hasher.hexdigest()
 
 def hash_str(string, blocksize=65536):
+    """" Hash a string """
     import hashlib
     hasher = hashlib.sha1()
     hasher.update(string.encode('utf-8'))
@@ -19,6 +21,7 @@ def hash_str(string, blocksize=65536):
     return hasher.hexdigest()
 
 def route_factory(app, docs, pairings, prepend='/api/'):
+    """ Create API routes and add to app """
     import resources
     for res_name, route in pairings:
         res = getattr(resources, res_name)
@@ -26,15 +29,9 @@ def route_factory(app, docs, pairings, prepend='/api/'):
                          view_func=res.as_view(res_name.lower()))
         docs.register(res)
 
-def generate_id(n=6):
-    import random
-    import string
-
-    return ''.join(random.SystemRandom().choice(
-        string.ascii_uppercase + string.digits) for _ in range(n))
-
 def remote_resource_exists(base_address, resource, raise_exception=False,
                  content_type='binary/octet-stream'):
+    """ Check if a remote address exists and content_type matches """
     address = urllib.parse.urljoin(base_address, resource)
     r = requests.head(address)
     if not r.ok or r.headers.get('Content-Type') != content_type:


### PR DESCRIPTION
WIP. Resolves:
 - #79 - Sends emails to users 

To-do

- [x] - Update API endpoint for register to call auth register_user (to send email). 
- [x] - Work on confirmation template. Shows a status message (success, etc) and redirect link back to app. Ideally, this would be an api call with a redirect, but need to think about this more.
- [x] - Do not allow unconfirmed users to get token (update tests for this as well)
- [x] - Log when users last accessed protected route - #150 (e.g. `last_access` field)
- [x] - Implement password reset email request
- [x] - Refactor email to have reusable send mail function and templates (like flask-security)