### PR TITLE
Filter runs in compile

### DIFF
--- a/neuroscout/tests/conftest.py
+++ b/neuroscout/tests/conftest.py
@@ -186,17 +186,17 @@ def add_analysis(session, add_users, add_task, extract_features):
               {
                 "name": "scale",
                 "input": [
-                  "BrightnessExtractor.Brightness"
+                  "Brightness"
                 ]
               }
             ],
             "model": {
               "HRF_variables": [
-                "BrightnessExtractor.Brightness",
+                "Brightness",
                 "rt"
               ],
               "variables": [
-                "BrightnessExtractor.Brightness",
+                "Brightness",
                 "rt"
               ]
             },
@@ -204,7 +204,7 @@ def add_analysis(session, add_users, add_task, extract_features):
               {
                 "name": "BvsRT",
                 "condition_list": [
-                  "BrightnessExtractor.Brightness",
+                  "Brightness",
                   "rt"
                 ],
                 "weights": [


### PR DESCRIPTION
Minor PR fixes:

- A bug where entities where not passed to `load_event_variables`, in case not all runs were select for a task
- Old reference to predictor names in test model