### PR TITLE
Transcript cutoffs and resample_ratio

### DIFF
--- a/neuroscout/config/transformers.json
+++ b/neuroscout/config/transformers.json
@@ -44,7 +44,7 @@
     {
       "function": "num_objects",
       "func_args": {"threshold": 0.07},
-      "new_name": "num_colors_0.07",
+      "new_name": "num_colors_0_07",
       "extractor_name": "GoogleVisionAPIPropertyExtractor"
     }
   ]

--- a/neuroscout/populate/convert.py
+++ b/neuroscout/populate/convert.py
@@ -155,6 +155,7 @@ def ingest_text_stimuli(filename, dataset_name, task_name, parent_ids,
     Args:
         filename - aligned transcript, with onset, duration and text columns
         dataset_name - Name of dataset in debug
+        task_name - Task name
         parent_ids - Parent stimulus db id(s)
         transformer - Transformer name
         params - Extra parameters to recordings
@@ -185,7 +186,7 @@ def ingest_text_stimuli(filename, dataset_name, task_name, parent_ids,
         if onset < 0:
             duration = duration - onset
         sub = sub[sub.onset < duration]
-
+        
         # Get associations with parent stimulus
         rs_orig = RunStimulus.query.filter_by(stimulus_id=parent_id).join(
             Run).join(Task).filter_by(name=task_name)

--- a/neuroscout/populate/convert.py
+++ b/neuroscout/populate/convert.py
@@ -10,7 +10,7 @@ from pliers.stimuli import (TextStim, ImageStim, VideoFrameStim,
 from pliers.transformers import get_transformer
 
 from models import Dataset, Task, Run, Stimulus, RunStimulus
-
+from utils.core import listify
 from .utils import hash_stim
 from .ingest import add_stimulus
 
@@ -148,25 +148,57 @@ def convert_stimuli(dataset_name, task_name, converters):
 
     return total_new_stims
 
-def ingest_text_stimuli(filename, dataset_name, task_name, parent_id,
-                        transformer, transformer_params=None, offset=0):
-    """ Ingest converted text stimuli from file. """
-    ## This ingests from a single parent stim. May want to refactor
-    ## for more complex files (e.g. multiple parents)
+def ingest_text_stimuli(filename, dataset_name, task_name, parent_ids,
+                        transformer='FAVEAlign', params=None, onsets=None):
+    """ Ingest converted text stimuli from file.
+    Args:
+        filename - aligned transcript, with onset, duration and text columns
+        dataset_name - Name of dataset in debug
+        parent_ids - Parent stimulus db id(s)
+        transformer - Transformer name
+        params - Extra parameters to recordings
+        onsets - onset of the parent stimulus relative to the transcript.
+    """
     df = pd.read_csv(filename, delimiter='\t')
+    parent_ids = listify(parent_ids)
+    onsets = listify(onsets)
+    if params is None:
+        params = {}
+
     dataset_id = Dataset.query.filter_by(name=dataset_name).one().id
 
-    ## Get associations with parent stimulus
-    rs_orig = RunStimulus.query.filter_by(stimulus_id=parent_id).join(
-        Run).join(Task).filter_by(name=task_name)
+    if onsets is None:
+        onsets = [0] * len(parent_ids)
+    if len(parent_ids) != len(onsets):
+        raise ValueError("parent_ids must match number of onsets")
 
-    if not rs_orig.count():
-        raise Exception("No RunStimulus associations match.")
+    for onset, parent_id in zip(onsets, parent_ids):
+        # Trim and align trancript
+        sub = df[df.onset > onset]
+        sub['onset'] = sub['onset'] - onset
 
-    new_stims = [
-        ComplexTextStim(text=row['text'], onset=row['onset'] + offset, duration=row.get('duration'))
-        for ix, row in df.iterrows()]
+        duration = max(db.session.query(RunStimulus.duration).filter_by(
+            stimulus_id=parent_id).distinct())[0]
+        if onset < 0:
+            duration = duration - onset
+        sub = sub[sub.onset < duration]
 
-    create_new_stimuli(
-        dataset_id, task_name, parent_id, new_stims, rs_orig,
-        transformer=transformer, transformer_params=transformer_params)
+        # Get associations with parent stimulus
+        rs_orig = RunStimulus.query.filter_by(stimulus_id=parent_id).join(
+            Run).join(Task).filter_by(name=task_name)
+
+        if not rs_orig.count():
+            raise Exception("No RunStimulus associations match.")
+
+        # Create new stimuli
+        new_stims = [
+            ComplexTextStim(text=row['text'], onset=row['onset'],
+                            duration=row.get('duration'))
+            for ix, row in sub.iterrows()]
+
+        params['onset'] = onset
+        params['duration'] = duration
+
+        create_new_stimuli(
+            dataset_id, task_name, parent_id, new_stims, rs_orig,
+            transformer=transformer, transformer_params=params)

--- a/neuroscout/tests/data/fake_transcript.csv
+++ b/neuroscout/tests/data/fake_transcript.csv
@@ -1,3 +1,3 @@
 onset	text	duration
-6.922	no	0.301
-7.223	young	0.399
+1.2	no	0.301
+3.223	young	0.399

--- a/neuroscout/tests/test_models.py
+++ b/neuroscout/tests/test_models.py
@@ -229,13 +229,12 @@ def test_external_text(get_data_path, add_task):
 	stim = Stimulus.query.filter_by(dataset_id=dataset_model.id).first()
 
 	ingest_text_stimuli(filename, dataset_model.name, task_name, stim.id,
-						'FakeTextExtraction')
+						transformer='FakeTextExtraction')
 
 	data = [s for s in Stimulus.query.all() if s.content is not None]
 
 	first_stim = [s for s in data if s.content == 'no'][0]
-	rs = RunStimulus.query.filter_by(stimulus_id=first_stim.id).all()
 
 	assert len(data) == 2
-	assert len(rs) == 4
-	assert 7.922 in [s.onset for s in rs]
+	assert first_stim.run_stimuli.count() == 4
+	assert 2.2 in [s.onset for s in first_stim.run_stimuli]


### PR DESCRIPTION
To ingest `Despicable Me` transcript, it was necessary to resample, or rather adjust the onsets by a ratio. It seems the stimulus used in the study was played 4-5% slower than the DVD version, and thus the script was off by a small amount. 

This also adds the ability to use a single transcript for several subclips (e.g. a single movie aligned transcript for 6 sub clips, each with their respective on/offsets).