### PR TITLE
FIX compile timeout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,10 @@ services:
     volumes:
       - migrations:/migrations
       - ./neuroscout/:/neuroscout
-      - $DATASET_DIR:/datasets
-      - $KEY_DIR:/keys
-      - file-data:/file-data
-    command: /usr/local/bin/gunicorn -w 2 -b :8000 core:app --log-level debug
+      - D:/neuroscout/datasets:/datasets
+      - D:/keys:/keys
+      - D:/neuroscout/file_data:/file-data
+    command: /usr/local/bin/gunicorn -w 2 -b :8000 core:app --log-level debug --timeout 300 --graceful-timeout 300
     env_file:
       - .env
       - .pliersenv
@@ -65,8 +65,8 @@ services:
       - redis
     entrypoint: celery -A tasks worker --loglevel=info
     volumes:
-      - file-data:/file-data
-      - $DATASET_DIR:/datasets
+      - D:/neuroscout/file_data:/file-data
+      - D:/neuroscout/datasets:/datasets
       - ./neuroscout/:/neuroscout
       - ./celery_worker/:/celery_worker
 

--- a/nginx/sites-enabled/flask_project
+++ b/nginx/sites-enabled/flask_project
@@ -14,6 +14,8 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_connect_timeout 75s;
+        proxy_read_timeout 300s;
     }
 
 


### PR DESCRIPTION
Fixes #239 by increasing timeout to 300s. Now most compile requests should pass, but it's still annoying to  have to wait that long, so in the future, it would be best to do long running SQL queries in celery itself (see other PR #242)